### PR TITLE
Bump Dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,9 +48,5 @@ plugins.withType<YarnPlugin> {
 }
 
 apiValidation {
-    if (CHECK_PUBLICATION) {
-        ignoredProjects.add("check-publication")
-    } else {
-        nonPublicMarkers.add("io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi")
-    }
+    if (CHECK_PUBLICATION) ignoredProjects.add("check-publication")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,11 +6,11 @@ encoding = "2.1.0"
 
 gradle-android = "8.1.4"
 gradle-binary-compat = "0.13.2"
-gradle-kmp-configuration = "0.1.6"
+gradle-kmp-configuration = "0.1.7"
 gradle-kotlin = "1.9.21"
 gradle-publish-maven = "0.25.3"
 
-kmp-file = "0.1.0-alpha02"
+kmp-file = "0.1.0-alpha03"
 
 kotlincrypto-hash = "0.4.0"
 kotlinx-atomicfu = "0.23.1"

--- a/library/core-resource/api/core-resource.api
+++ b/library/core-resource/api/core-resource.api
@@ -1,13 +1,223 @@
 public final class io/matthewnelson/kmp/tor/core/resource/AndroidSdkIntKt {
+	public static final fun getANDROID_SDK_INT ()Ljava/lang/Integer;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/ImmutableMap : java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
+	public static final field Companion Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap$Companion;
+	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun clear ()V
+	public fun compute (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
+	public fun computeIfPresent (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun containsKey (Ljava/lang/Object;)Z
+	public fun containsValue (Ljava/lang/Object;)Z
+	public final fun entrySet ()Ljava/util/Set;
+	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun getEntries ()Ljava/util/Set;
+	public fun getKeys ()Ljava/util/Set;
+	public fun getSize ()I
+	public fun getValues ()Ljava/util/Collection;
+	public fun isEmpty ()Z
+	public final fun keySet ()Ljava/util/Set;
+	public fun merge (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public static final fun of ([Lkotlin/Pair;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap;
+	public fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putAll (Ljava/util/Map;)V
+	public fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public fun replace (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun replace (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
+	public fun replaceAll (Ljava/util/function/BiFunction;)V
+	public final fun size ()I
+	public static final fun toImmutableMap (Ljava/util/Map;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap;
+	public final fun values ()Ljava/util/Collection;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/ImmutableMap$Companion {
+	public final fun of ([Lkotlin/Pair;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap;
+	public final fun toImmutableMap (Ljava/util/Map;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/ImmutableSet : java/util/Set, kotlin/jvm/internal/markers/KMappedMarker {
+	public static final field Companion Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet$Companion;
+	public synthetic fun <init> (Ljava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun add (Ljava/lang/Object;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public fun contains (Ljava/lang/Object;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	public fun getSize ()I
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public static final fun of ([Ljava/lang/Object;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
+	public fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun retainAll (Ljava/util/Collection;)Z
+	public final fun size ()I
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public static final fun toImmutableSet (Ljava/util/Set;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/ImmutableSet$Companion {
+	public final fun of ([Ljava/lang/Object;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
+	public final fun toImmutableSet (Ljava/util/Set;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
+}
+
+public abstract class io/matthewnelson/kmp/tor/core/resource/OSArch {
+	public final field path Ljava/lang/String;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSArch$Aarch64 : io/matthewnelson/kmp/tor/core/resource/OSArch {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSArch$Aarch64;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSArch$Armv7 : io/matthewnelson/kmp/tor/core/resource/OSArch {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSArch$Armv7;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSArch$Ppc64 : io/matthewnelson/kmp/tor/core/resource/OSArch {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSArch$Ppc64;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSArch$Unsupported : io/matthewnelson/kmp/tor/core/resource/OSArch {
+	public final field arch Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSArch$X86 : io/matthewnelson/kmp/tor/core/resource/OSArch {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSArch$X86;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSArch$X86_64 : io/matthewnelson/kmp/tor/core/resource/OSArch {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSArch$X86_64;
+}
+
+public abstract class io/matthewnelson/kmp/tor/core/resource/OSHost {
+	public final field path Ljava/lang/String;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSHost$FreeBSD : io/matthewnelson/kmp/tor/core/resource/OSHost {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSHost$FreeBSD;
+}
+
+public abstract class io/matthewnelson/kmp/tor/core/resource/OSHost$Linux : io/matthewnelson/kmp/tor/core/resource/OSHost {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSHost$Linux$Android : io/matthewnelson/kmp/tor/core/resource/OSHost$Linux {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSHost$Linux$Android;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSHost$Linux$Libc : io/matthewnelson/kmp/tor/core/resource/OSHost$Linux {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSHost$Linux$Libc;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSHost$Linux$Musl : io/matthewnelson/kmp/tor/core/resource/OSHost$Linux {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSHost$Linux$Musl;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSHost$MacOS : io/matthewnelson/kmp/tor/core/resource/OSHost {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSHost$MacOS;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSHost$Unknown : io/matthewnelson/kmp/tor/core/resource/OSHost {
+	public final field name Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSHost$Windows : io/matthewnelson/kmp/tor/core/resource/OSHost {
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSHost$Windows;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/OSInfo {
+	public static final field Companion Lio/matthewnelson/kmp/tor/core/resource/OSInfo$Companion;
+	public static final field INSTANCE Lio/matthewnelson/kmp/tor/core/resource/OSInfo;
+	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/core/resource/internal/ProcessRunner;Ljava/io/File;Ljava/io/File;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final synthetic fun get$core_resource (Lio/matthewnelson/kmp/tor/core/resource/internal/ProcessRunner;Ljava/io/File;Ljava/io/File;Lkotlin/jvm/functions/Function0;)Lio/matthewnelson/kmp/tor/core/resource/OSInfo;
+	public final fun isAndroidRuntime ()Z
+	public final fun osArch ()Lio/matthewnelson/kmp/tor/core/resource/OSArch;
+	public final fun osHost ()Lio/matthewnelson/kmp/tor/core/resource/OSHost;
 }
 
 public final class io/matthewnelson/kmp/tor/core/resource/OSInfo$Companion {
 }
 
+public final class io/matthewnelson/kmp/tor/core/resource/PlatformResource {
+	public final field resourceClass Ljava/lang/Class;
+	public final field resourcePath Ljava/lang/String;
+	public synthetic fun <init> (Ljava/lang/Class;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/PlatformResource$Builder {
+	public field resourceClass Ljava/lang/Class;
+	public field resourcePath Ljava/lang/String;
+}
+
 public final class io/matthewnelson/kmp/tor/core/resource/ProcessExt {
+	public static final fun forciblyDestroy (Ljava/lang/Process;)Ljava/lang/Process;
+	public static final fun waitFor-8Mi8wO0 (Ljava/lang/Process;JZ)Z
+	public static synthetic fun waitFor-8Mi8wO0$default (Ljava/lang/Process;JZILjava/lang/Object;)Z
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/Resource {
+	public final field alias Ljava/lang/String;
+	public final field isExecutable Z
+	public final field platform Lio/matthewnelson/kmp/tor/core/resource/PlatformResource;
+	public synthetic fun <init> (Ljava/lang/String;ZLio/matthewnelson/kmp/tor/core/resource/PlatformResource;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/Resource$Builder {
+	public final field alias Ljava/lang/String;
+	public field isExecutable Z
+	public final fun platform (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/kmp/tor/core/resource/Resource$Builder;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/Resource$Config {
+	public static final field Companion Lio/matthewnelson/kmp/tor/core/resource/Resource$Config$Companion;
+	public final field errors Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
+	public final field resources Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
+	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/kmp/tor/core/resource/Resource$Config;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun extractTo (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/Resource$Config$Builder {
+	public final fun error (Ljava/lang/String;)Lio/matthewnelson/kmp/tor/core/resource/Resource$Config$Builder;
+	public final fun resource (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lio/matthewnelson/kmp/tor/core/resource/Resource$Config$Builder;
+	public static synthetic fun resource$default (Lio/matthewnelson/kmp/tor/core/resource/Resource$Config$Builder;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/matthewnelson/kmp/tor/core/resource/Resource$Config$Builder;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/Resource$Config$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/kmp/tor/core/resource/Resource$Config;
 }
 
 public final class io/matthewnelson/kmp/tor/core/resource/SynchronizedCommon {
+	public static final fun synchronized (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public final class io/matthewnelson/kmp/tor/core/resource/SynchronizedJvm {


### PR DESCRIPTION
Also removes the `InternalKmpTorApi` annotation marker from the binary compatibility validator plugin in order to monitor potential API breaking changes in the future.