### PR TITLE
Reworks `Immutable` implementations

### DIFF
--- a/library/core-resource/api/core-resource.api
+++ b/library/core-resource/api/core-resource.api
@@ -2,6 +2,47 @@ public final class io/matthewnelson/kmp/tor/core/resource/AndroidSdkIntKt {
 	public static final fun getANDROID_SDK_INT ()Ljava/lang/Integer;
 }
 
+public final class io/matthewnelson/kmp/tor/core/resource/ImmutableList : java/util/List, kotlin/jvm/internal/markers/KMappedMarker {
+	public static final field Companion Lio/matthewnelson/kmp/tor/core/resource/ImmutableList$Companion;
+	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun add (ILjava/lang/Object;)V
+	public fun add (Ljava/lang/Object;)Z
+	public fun addAll (ILjava/util/Collection;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public fun contains (Ljava/lang/Object;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public fun get (I)Ljava/lang/Object;
+	public static final fun get (Ljava/util/Collection;)Ljava/util/List;
+	public fun getSize ()I
+	public fun hashCode ()I
+	public fun indexOf (Ljava/lang/Object;)I
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public fun lastIndexOf (Ljava/lang/Object;)I
+	public fun listIterator ()Ljava/util/ListIterator;
+	public fun listIterator (I)Ljava/util/ListIterator;
+	public static final fun of ([Ljava/lang/Object;)Ljava/util/List;
+	public fun remove (I)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun replaceAll (Ljava/util/function/UnaryOperator;)V
+	public fun retainAll (Ljava/util/Collection;)Z
+	public fun set (ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun size ()I
+	public fun sort (Ljava/util/Comparator;)V
+	public fun subList (II)Ljava/util/List;
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/matthewnelson/kmp/tor/core/resource/ImmutableList$Companion {
+	public final fun get (Ljava/util/Collection;)Ljava/util/List;
+	public final fun of ([Ljava/lang/Object;)Ljava/util/List;
+}
+
 public final class io/matthewnelson/kmp/tor/core/resource/ImmutableMap : java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
 	public static final field Companion Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap$Companion;
 	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -12,15 +53,18 @@ public final class io/matthewnelson/kmp/tor/core/resource/ImmutableMap : java/ut
 	public fun containsKey (Ljava/lang/Object;)Z
 	public fun containsValue (Ljava/lang/Object;)Z
 	public final fun entrySet ()Ljava/util/Set;
+	public fun equals (Ljava/lang/Object;)Z
 	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun get (Ljava/util/Map;)Ljava/util/Map;
 	public fun getEntries ()Ljava/util/Set;
 	public fun getKeys ()Ljava/util/Set;
 	public fun getSize ()I
 	public fun getValues ()Ljava/util/Collection;
+	public fun hashCode ()I
 	public fun isEmpty ()Z
 	public final fun keySet ()Ljava/util/Set;
 	public fun merge (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
-	public static final fun of ([Lkotlin/Pair;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap;
+	public static final fun of ([Lkotlin/Pair;)Ljava/util/Map;
 	public fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun putAll (Ljava/util/Map;)V
 	public fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
@@ -30,13 +74,13 @@ public final class io/matthewnelson/kmp/tor/core/resource/ImmutableMap : java/ut
 	public fun replace (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
 	public fun replaceAll (Ljava/util/function/BiFunction;)V
 	public final fun size ()I
-	public static final fun toImmutableMap (Ljava/util/Map;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap;
+	public fun toString ()Ljava/lang/String;
 	public final fun values ()Ljava/util/Collection;
 }
 
 public final class io/matthewnelson/kmp/tor/core/resource/ImmutableMap$Companion {
-	public final fun of ([Lkotlin/Pair;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap;
-	public final fun toImmutableMap (Ljava/util/Map;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap;
+	public final fun get (Ljava/util/Map;)Ljava/util/Map;
+	public final fun of ([Lkotlin/Pair;)Ljava/util/Map;
 }
 
 public final class io/matthewnelson/kmp/tor/core/resource/ImmutableSet : java/util/Set, kotlin/jvm/internal/markers/KMappedMarker {
@@ -47,22 +91,25 @@ public final class io/matthewnelson/kmp/tor/core/resource/ImmutableSet : java/ut
 	public fun clear ()V
 	public fun contains (Ljava/lang/Object;)Z
 	public fun containsAll (Ljava/util/Collection;)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun get (Ljava/util/Collection;)Ljava/util/Set;
 	public fun getSize ()I
+	public fun hashCode ()I
 	public fun isEmpty ()Z
 	public fun iterator ()Ljava/util/Iterator;
-	public static final fun of ([Ljava/lang/Object;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
+	public static final fun of ([Ljava/lang/Object;)Ljava/util/Set;
 	public fun remove (Ljava/lang/Object;)Z
 	public fun removeAll (Ljava/util/Collection;)Z
 	public fun retainAll (Ljava/util/Collection;)Z
 	public final fun size ()I
 	public fun toArray ()[Ljava/lang/Object;
 	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
-	public static final fun toImmutableSet (Ljava/util/Set;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/matthewnelson/kmp/tor/core/resource/ImmutableSet$Companion {
-	public final fun of ([Ljava/lang/Object;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
-	public final fun toImmutableSet (Ljava/util/Set;)Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
+	public final fun get (Ljava/util/Collection;)Ljava/util/Set;
+	public final fun of ([Ljava/lang/Object;)Ljava/util/Set;
 }
 
 public abstract class io/matthewnelson/kmp/tor/core/resource/OSArch {
@@ -196,12 +243,12 @@ public final class io/matthewnelson/kmp/tor/core/resource/Resource$Builder {
 
 public final class io/matthewnelson/kmp/tor/core/resource/Resource$Config {
 	public static final field Companion Lio/matthewnelson/kmp/tor/core/resource/Resource$Config$Companion;
-	public final field errors Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
-	public final field resources Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;
-	public synthetic fun <init> (Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final field errors Ljava/util/Set;
+	public final field resources Ljava/util/Set;
+	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun create (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/kmp/tor/core/resource/Resource$Config;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun extractTo (Ljava/io/File;Z)Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap;
+	public final fun extractTo (Ljava/io/File;Z)Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/library/core-resource/api/core-resource.api
+++ b/library/core-resource/api/core-resource.api
@@ -2,114 +2,13 @@ public final class io/matthewnelson/kmp/tor/core/resource/AndroidSdkIntKt {
 	public static final fun getANDROID_SDK_INT ()Ljava/lang/Integer;
 }
 
-public final class io/matthewnelson/kmp/tor/core/resource/ImmutableList : java/util/List, kotlin/jvm/internal/markers/KMappedMarker {
-	public static final field Companion Lio/matthewnelson/kmp/tor/core/resource/ImmutableList$Companion;
-	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun add (ILjava/lang/Object;)V
-	public fun add (Ljava/lang/Object;)Z
-	public fun addAll (ILjava/util/Collection;)Z
-	public fun addAll (Ljava/util/Collection;)Z
-	public fun clear ()V
-	public fun contains (Ljava/lang/Object;)Z
-	public fun containsAll (Ljava/util/Collection;)Z
-	public fun equals (Ljava/lang/Object;)Z
-	public fun get (I)Ljava/lang/Object;
-	public static final fun get (Ljava/util/Collection;)Ljava/util/List;
-	public fun getSize ()I
-	public fun hashCode ()I
-	public fun indexOf (Ljava/lang/Object;)I
-	public fun isEmpty ()Z
-	public fun iterator ()Ljava/util/Iterator;
-	public fun lastIndexOf (Ljava/lang/Object;)I
-	public fun listIterator ()Ljava/util/ListIterator;
-	public fun listIterator (I)Ljava/util/ListIterator;
-	public static final fun of ([Ljava/lang/Object;)Ljava/util/List;
-	public fun remove (I)Ljava/lang/Object;
-	public fun remove (Ljava/lang/Object;)Z
-	public fun removeAll (Ljava/util/Collection;)Z
-	public fun replaceAll (Ljava/util/function/UnaryOperator;)V
-	public fun retainAll (Ljava/util/Collection;)Z
-	public fun set (ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun size ()I
-	public fun sort (Ljava/util/Comparator;)V
-	public fun subList (II)Ljava/util/List;
-	public fun toArray ()[Ljava/lang/Object;
-	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/matthewnelson/kmp/tor/core/resource/ImmutableList$Companion {
-	public final fun get (Ljava/util/Collection;)Ljava/util/List;
-	public final fun of ([Ljava/lang/Object;)Ljava/util/List;
-}
-
-public final class io/matthewnelson/kmp/tor/core/resource/ImmutableMap : java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
-	public static final field Companion Lio/matthewnelson/kmp/tor/core/resource/ImmutableMap$Companion;
-	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun clear ()V
-	public fun compute (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
-	public fun computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
-	public fun computeIfPresent (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
-	public fun containsKey (Ljava/lang/Object;)Z
-	public fun containsValue (Ljava/lang/Object;)Z
-	public final fun entrySet ()Ljava/util/Set;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun get (Ljava/lang/Object;)Ljava/lang/Object;
-	public static final fun get (Ljava/util/Map;)Ljava/util/Map;
-	public fun getEntries ()Ljava/util/Set;
-	public fun getKeys ()Ljava/util/Set;
-	public fun getSize ()I
-	public fun getValues ()Ljava/util/Collection;
-	public fun hashCode ()I
-	public fun isEmpty ()Z
-	public final fun keySet ()Ljava/util/Set;
-	public fun merge (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
-	public static final fun of ([Lkotlin/Pair;)Ljava/util/Map;
-	public fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun putAll (Ljava/util/Map;)V
-	public fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun remove (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun remove (Ljava/lang/Object;Ljava/lang/Object;)Z
-	public fun replace (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun replace (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
-	public fun replaceAll (Ljava/util/function/BiFunction;)V
-	public final fun size ()I
-	public fun toString ()Ljava/lang/String;
-	public final fun values ()Ljava/util/Collection;
-}
-
-public final class io/matthewnelson/kmp/tor/core/resource/ImmutableMap$Companion {
-	public final fun get (Ljava/util/Map;)Ljava/util/Map;
-	public final fun of ([Lkotlin/Pair;)Ljava/util/Map;
-}
-
-public final class io/matthewnelson/kmp/tor/core/resource/ImmutableSet : java/util/Set, kotlin/jvm/internal/markers/KMappedMarker {
-	public static final field Companion Lio/matthewnelson/kmp/tor/core/resource/ImmutableSet$Companion;
-	public synthetic fun <init> (Ljava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun add (Ljava/lang/Object;)Z
-	public fun addAll (Ljava/util/Collection;)Z
-	public fun clear ()V
-	public fun contains (Ljava/lang/Object;)Z
-	public fun containsAll (Ljava/util/Collection;)Z
-	public fun equals (Ljava/lang/Object;)Z
-	public static final fun get (Ljava/util/Collection;)Ljava/util/Set;
-	public fun getSize ()I
-	public fun hashCode ()I
-	public fun isEmpty ()Z
-	public fun iterator ()Ljava/util/Iterator;
-	public static final fun of ([Ljava/lang/Object;)Ljava/util/Set;
-	public fun remove (Ljava/lang/Object;)Z
-	public fun removeAll (Ljava/util/Collection;)Z
-	public fun retainAll (Ljava/util/Collection;)Z
-	public final fun size ()I
-	public fun toArray ()[Ljava/lang/Object;
-	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/matthewnelson/kmp/tor/core/resource/ImmutableSet$Companion {
-	public final fun get (Ljava/util/Collection;)Ljava/util/Set;
-	public final fun of ([Ljava/lang/Object;)Ljava/util/Set;
+public final class io/matthewnelson/kmp/tor/core/resource/Immutable {
+	public static final fun listOf (Ljava/util/Collection;)Ljava/util/List;
+	public static final fun listOf ([Ljava/lang/Object;)Ljava/util/List;
+	public static final fun mapOf (Ljava/util/Map;)Ljava/util/Map;
+	public static final fun mapOf ([Lkotlin/Pair;)Ljava/util/Map;
+	public static final fun setOf (Ljava/util/Collection;)Ljava/util/Set;
+	public static final fun setOf ([Ljava/lang/Object;)Ljava/util/Set;
 }
 
 public abstract class io/matthewnelson/kmp/tor/core/resource/OSArch {

--- a/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
+++ b/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
@@ -37,10 +37,17 @@ public class ImmutableSet<T> private constructor(
     public companion object {
 
         @JvmStatic
-        public fun <T> MutableSet<T>.toImmutableSet(): ImmutableSet<T> = ImmutableSet(this.toSet())
+        public fun <T> Set<T>.toImmutableSet(): Set<T> {
+            if (isEmpty()) return emptySet()
+            if (this is ImmutableSet<T>) return this
+            return ImmutableSet(toSet())
+        }
 
         @JvmStatic
-        public fun <T> of(vararg elements: T): ImmutableSet<T> = ImmutableSet(elements.toSet())
+        public fun <T> of(vararg elements: T): Set<T> {
+            if (elements.isEmpty()) return emptySet()
+            return ImmutableSet(elements.toSet())
+        }
     }
 }
 
@@ -66,9 +73,16 @@ public class ImmutableMap<K, V> private constructor(
     public companion object {
 
         @JvmStatic
-        public fun <K, V> MutableMap<K, V>.toImmutableMap(): ImmutableMap<K, V> = ImmutableMap(this.toMap())
+        public fun <K, V> Map<K, V>.toImmutableMap(): Map<K, V> {
+            if (isEmpty()) return emptyMap()
+            if (this is ImmutableMap<K, V>) return this
+            return ImmutableMap(toMap())
+        }
 
         @JvmStatic
-        public fun <K, V> of(vararg pairs: Pair<K, V>): ImmutableMap<K, V> = ImmutableMap(pairs.toMap())
+        public fun <K, V> of(vararg pairs: Pair<K, V>): Map<K, V> {
+            if (pairs.isEmpty()) return emptyMap()
+            return ImmutableMap(pairs.toMap())
+        }
     }
 }

--- a/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
+++ b/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
@@ -100,15 +100,15 @@ public class ImmutableMap<K, V> private constructor(
         override fun toString(): String = delegate.toString()
     }
 
-    override val entries: Set<Map.Entry<K, V>> get() {
+    override val entries: Set<Map.Entry<K, V>> by lazy {
         val entries = delegate.entries
         val set = HashSet<Entry<K, V>>(entries.size, 1.0F)
         entries.mapTo(set) { Entry(it) }
-        return set.wrapImmutableSet()
+        set.wrapImmutableSet()
     }
-    override val keys: Set<K> get() = delegate.keys.wrapImmutableSet()
+    override val keys: Set<K> by lazy { delegate.keys.wrapImmutableSet() }
     override val size: Int get() = delegate.size
-    override val values: Collection<V> get() = Values(delegate.values)
+    override val values: Collection<V> by lazy { Values(delegate.values) }
     override fun isEmpty(): Boolean = delegate.isEmpty()
     override operator fun get(key: K): V? = delegate[key]
     override fun containsValue(value: V): Boolean = delegate.containsValue(value)

--- a/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
+++ b/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
@@ -16,7 +16,6 @@
 package io.matthewnelson.kmp.tor.core.resource
 
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
-import io.matthewnelson.kmp.tor.core.resource.ImmutableList.Companion.wrapImmutableList
 import io.matthewnelson.kmp.tor.core.resource.ImmutableSet.Companion.wrapImmutableSet
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
@@ -74,11 +73,25 @@ public class ImmutableMap<K, V> private constructor(
     private val delegate: Map<K, V>,
 ): Map<K, V> {
 
-    internal class Entry<K, V>(
+    private class Entry<K, V>(
         private val delegate: Map.Entry<K, V>,
     ): Map.Entry<K, V> {
         override val key: K get() = delegate.key
         override val value: V get() = delegate.value
+
+        override fun equals(other: Any?): Boolean = delegate == other
+        override fun hashCode(): Int = delegate.hashCode()
+        override fun toString(): String = delegate.toString()
+    }
+
+    private class Values<V>(
+        private val delegate: Collection<V>,
+    ): Collection<V> {
+        override val size: Int get() = delegate.size
+        override fun isEmpty(): Boolean = delegate.isEmpty()
+        override fun iterator(): Iterator<V> = delegate.iterator()
+        override fun containsAll(elements: Collection<V>): Boolean = delegate.containsAll(elements)
+        override fun contains(element: V): Boolean = delegate.contains(element)
 
         override fun equals(other: Any?): Boolean = delegate == other
         override fun hashCode(): Int = delegate.hashCode()
@@ -93,7 +106,7 @@ public class ImmutableMap<K, V> private constructor(
     }
     override val keys: Set<K> get() = delegate.keys.wrapImmutableSet()
     override val size: Int get() = delegate.size
-    override val values: Collection<V> get() = delegate.values.wrapImmutableList()
+    override val values: Collection<V> get() = Values(delegate.values)
     override fun isEmpty(): Boolean = delegate.isEmpty()
     override operator fun get(key: K): V? = delegate[key]
     override fun containsValue(value: V): Boolean = delegate.containsValue(value)

--- a/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
+++ b/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
@@ -17,6 +17,7 @@ package io.matthewnelson.kmp.tor.core.resource
 
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.core.resource.ImmutableSet.Companion.wrapImmutableSet
+import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
 
@@ -46,6 +47,7 @@ public class ImmutableList<T> private constructor(
     public companion object {
 
         @JvmStatic
+        @JvmName("get")
         public fun <T> Collection<T>.toImmutableList(): List<T> {
             if (isEmpty()) return emptyList()
             if (this is ImmutableList<T>) return this
@@ -120,6 +122,7 @@ public class ImmutableMap<K, V> private constructor(
     public companion object {
 
         @JvmStatic
+        @JvmName("get")
         public fun <K, V> Map<K, V>.toImmutableMap(): Map<K, V> {
             if (isEmpty()) return emptyMap()
             if (this is ImmutableMap<K, V>) return this
@@ -160,6 +163,7 @@ public class ImmutableSet<T> private constructor(
     public companion object {
 
         @JvmStatic
+        @JvmName("get")
         public fun <T> Collection<T>.toImmutableSet(): Set<T> {
             if (isEmpty()) return emptySet()
             if (this is ImmutableSet<T>) return this

--- a/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
+++ b/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
@@ -16,16 +16,25 @@
 package io.matthewnelson.kmp.tor.core.resource
 
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.core.resource.ImmutableList.Companion.toImmutableList
+import io.matthewnelson.kmp.tor.core.resource.ImmutableSet.Companion.toImmutableSet
 import kotlin.jvm.JvmStatic
 
 @InternalKmpTorApi
-public class ImmutableSet<T> private constructor(
-    private val delegate: Set<T>
-): Set<T> {
+public class ImmutableList<T> private constructor(
+    private val delegate: List<T>,
+): List<T> {
 
     override val size: Int get() = delegate.size
+    override operator fun get(index: Int): T = delegate[index]
     override fun isEmpty(): Boolean = delegate.isEmpty()
     override fun iterator(): Iterator<T> = delegate.iterator()
+    override fun listIterator(): ListIterator<T> = delegate.listIterator()
+    override fun listIterator(index: Int): ListIterator<T> = delegate.listIterator(index)
+
+    override fun subList(fromIndex: Int, toIndex: Int): List<T> = ImmutableList(delegate.subList(fromIndex, toIndex))
+    override fun lastIndexOf(element: T): Int = delegate.lastIndexOf(element)
+    override fun indexOf(element: T): Int = delegate.indexOf(element)
     override fun containsAll(elements: Collection<T>): Boolean = delegate.containsAll(elements)
     override fun contains(element: T): Boolean = delegate.contains(element)
 
@@ -37,29 +46,40 @@ public class ImmutableSet<T> private constructor(
     public companion object {
 
         @JvmStatic
-        public fun <T> Set<T>.toImmutableSet(): Set<T> {
-            if (isEmpty()) return emptySet()
-            if (this is ImmutableSet<T>) return this
-            return ImmutableSet(toSet())
+        public fun <T> Collection<T>.toImmutableList(): List<T> {
+            if (isEmpty()) return emptyList()
+            if (this is ImmutableList<T>) return this
+            return ImmutableList(toList())
         }
 
         @JvmStatic
-        public fun <T> of(vararg elements: T): Set<T> {
-            if (elements.isEmpty()) return emptySet()
-            return ImmutableSet(elements.toSet())
+        public fun <T> of(vararg elements: T): List<T> {
+            if (elements.isEmpty()) return emptyList()
+            return ImmutableList(elements.toList())
         }
     }
 }
 
 @InternalKmpTorApi
 public class ImmutableMap<K, V> private constructor(
-    private val delegate: Map<K, V>
+    private val delegate: Map<K, V>,
 ): Map<K, V> {
 
-    override val entries: Set<Map.Entry<K, V>> get() = delegate.entries
-    override val keys: Set<K> get() = delegate.keys
+    internal class Entry<K, V>(
+        private val delegate: Map.Entry<K, V>,
+    ): Map.Entry<K, V> {
+        override val key: K get() = delegate.key
+        override val value: V get() = delegate.value
+
+        override fun equals(other: Any?): Boolean = delegate == other
+        override fun hashCode(): Int = delegate.hashCode()
+        override fun toString(): String = delegate.toString()
+    }
+
+    override val entries: Set<Map.Entry<K, V>> get() = delegate.entries.map { Entry(it) }.toImmutableSet()
+    override val keys: Set<K> get() = delegate.keys.toImmutableSet()
     override val size: Int get() = delegate.size
-    override val values: Collection<V> get() = delegate.values
+    override val values: Collection<V> get() = delegate.values.toImmutableList()
     override fun isEmpty(): Boolean = delegate.isEmpty()
     override operator fun get(key: K): V? = delegate[key]
     override fun containsValue(value: V): Boolean = delegate.containsValue(value)
@@ -83,6 +103,39 @@ public class ImmutableMap<K, V> private constructor(
         public fun <K, V> of(vararg pairs: Pair<K, V>): Map<K, V> {
             if (pairs.isEmpty()) return emptyMap()
             return ImmutableMap(pairs.toMap())
+        }
+    }
+}
+
+@InternalKmpTorApi
+public class ImmutableSet<T> private constructor(
+    private val delegate: Set<T>,
+): Set<T> {
+
+    override val size: Int get() = delegate.size
+    override fun isEmpty(): Boolean = delegate.isEmpty()
+    override fun iterator(): Iterator<T> = delegate.iterator()
+    override fun containsAll(elements: Collection<T>): Boolean = delegate.containsAll(elements)
+    override fun contains(element: T): Boolean = delegate.contains(element)
+
+    override fun equals(other: Any?): Boolean = delegate == other
+    override fun hashCode(): Int = delegate.hashCode()
+    override fun toString(): String = delegate.toString()
+
+    @InternalKmpTorApi
+    public companion object {
+
+        @JvmStatic
+        public fun <T> Collection<T>.toImmutableSet(): Set<T> {
+            if (isEmpty()) return emptySet()
+            if (this is ImmutableSet<T>) return this
+            return ImmutableSet(toSet())
+        }
+
+        @JvmStatic
+        public fun <T> of(vararg elements: T): Set<T> {
+            if (elements.isEmpty()) return emptySet()
+            return ImmutableSet(elements.toSet())
         }
     }
 }

--- a/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
+++ b/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
@@ -29,6 +29,10 @@ public class ImmutableSet<T> private constructor(
     override fun containsAll(elements: Collection<T>): Boolean = delegate.containsAll(elements)
     override fun contains(element: T): Boolean = delegate.contains(element)
 
+    override fun equals(other: Any?): Boolean = delegate == other
+    override fun hashCode(): Int = delegate.hashCode()
+    override fun toString(): String = delegate.toString()
+
     @InternalKmpTorApi
     public companion object {
 
@@ -53,6 +57,10 @@ public class ImmutableMap<K, V> private constructor(
     override operator fun get(key: K): V? = delegate[key]
     override fun containsValue(value: V): Boolean = delegate.containsValue(value)
     override fun containsKey(key: K): Boolean = delegate.containsKey(key)
+
+    override fun equals(other: Any?): Boolean = delegate == other
+    override fun hashCode(): Int = delegate.hashCode()
+    override fun toString(): String = delegate.toString()
 
     @InternalKmpTorApi
     public companion object {

--- a/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Resource.kt
+++ b/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Resource.kt
@@ -19,12 +19,10 @@ import io.matthewnelson.kmp.file.File
 import io.matthewnelson.kmp.file.IOException
 import io.matthewnelson.kmp.file.canonicalFile
 import io.matthewnelson.kmp.file.wrapIOException
-import io.matthewnelson.kmp.tor.core.resource.ImmutableSet.Companion.toImmutableSet
 import io.matthewnelson.kmp.tor.core.resource.internal.appendIndent
 import io.matthewnelson.kmp.tor.core.resource.internal.extractTo
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.core.api.annotation.KmpTorDsl
-import io.matthewnelson.kmp.tor.core.resource.ImmutableMap.Companion.wrapImmutableMap
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
@@ -90,7 +88,7 @@ public class Resource private constructor(
                 throw t.wrapIOException { "Failed to extract resources to destinationDir[$dir]" }
             }
 
-            return map.wrapImmutableMap()
+            return map.toImmutableMap()
         }
 
         @KmpTorDsl

--- a/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Resource.kt
+++ b/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Resource.kt
@@ -42,9 +42,9 @@ public class Resource private constructor(
     @InternalKmpTorApi
     public class Config private constructor(
         @JvmField
-        public val errors: ImmutableSet<String>,
+        public val errors: Set<String>,
         @JvmField
-        public val resources: ImmutableSet<Resource>,
+        public val resources: Set<Resource>,
     ) {
 
         @InternalKmpTorApi
@@ -58,7 +58,7 @@ public class Resource private constructor(
         }
 
         @Throws(IllegalStateException::class, IOException::class)
-        public fun extractTo(destinationDir: File, onlyIfDoesNotExist: Boolean): ImmutableMap<String, File> {
+        public fun extractTo(destinationDir: File, onlyIfDoesNotExist: Boolean): Map<String, File> {
             check(errors.isEmpty()) {
                 buildString {
                     errors.forEach { error ->

--- a/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Resource.kt
+++ b/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Resource.kt
@@ -19,12 +19,12 @@ import io.matthewnelson.kmp.file.File
 import io.matthewnelson.kmp.file.IOException
 import io.matthewnelson.kmp.file.canonicalFile
 import io.matthewnelson.kmp.file.wrapIOException
-import io.matthewnelson.kmp.tor.core.resource.ImmutableMap.Companion.toImmutableMap
 import io.matthewnelson.kmp.tor.core.resource.ImmutableSet.Companion.toImmutableSet
 import io.matthewnelson.kmp.tor.core.resource.internal.appendIndent
 import io.matthewnelson.kmp.tor.core.resource.internal.extractTo
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.core.api.annotation.KmpTorDsl
+import io.matthewnelson.kmp.tor.core.resource.ImmutableMap.Companion.wrapImmutableMap
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
@@ -90,7 +90,7 @@ public class Resource private constructor(
                 throw t.wrapIOException { "Failed to extract resources to destinationDir[$dir]" }
             }
 
-            return map.toImmutableMap()
+            return map.wrapImmutableMap()
         }
 
         @KmpTorDsl

--- a/library/core-resource/src/commonTest/kotlin/io/matthewnelson/kmp/tor/core/resource/ImmutableUnitTest.kt
+++ b/library/core-resource/src/commonTest/kotlin/io/matthewnelson/kmp/tor/core/resource/ImmutableUnitTest.kt
@@ -16,9 +16,6 @@
 package io.matthewnelson.kmp.tor.core.resource
 
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
-import io.matthewnelson.kmp.tor.core.resource.ImmutableList.Companion.toImmutableList
-import io.matthewnelson.kmp.tor.core.resource.ImmutableMap.Companion.toImmutableMap
-import io.matthewnelson.kmp.tor.core.resource.ImmutableSet.Companion.toImmutableSet
 import kotlin.test.*
 
 @OptIn(InternalKmpTorApi::class)
@@ -32,7 +29,10 @@ class ImmutableUnitTest {
 
         val iList1 = list1.toImmutableList()
         val iList2 = list2.toImmutableList()
-        assertIs<ImmutableList<String>>(iList1.subList(0, 2))
+        assertEquals("ImmutableList", iList1::class.simpleName)
+        assertNotEquals("ImmutableList", emptyList<String>().toImmutableList()::class.simpleName)
+        assertNotEquals("ImmutableList", immutableListOf<String>()::class.simpleName)
+
         assertEquals(iList1, iList2)
         assertEquals(iList1.toString(), iList2.toString())
         assertEquals(iList1.hashCode(), iList2.hashCode())
@@ -41,6 +41,7 @@ class ImmutableUnitTest {
         assertEquals(list1.toString(), iList1.toString())
         assertEquals(list1.hashCode(), iList1.hashCode())
     }
+
     @Test
     fun givenContents_whenTheSame_thenImmutableMapEqualsOther() {
         val map1 = mutableMapOf("this" to "that", "here" to "there")
@@ -52,8 +53,9 @@ class ImmutableUnitTest {
 
         val iMap1 = map1.toImmutableMap()
         val iMap2 = map2.toImmutableMap()
-        assertIs<ImmutableSet<String>>(iMap1.entries)
-        assertIs<ImmutableSet<String>>(iMap1.keys)
+        assertEquals("ImmutableMap", iMap1::class.simpleName)
+        assertNotEquals("ImmutableMap", emptyMap<String, String>().toImmutableMap()::class.simpleName)
+        assertNotEquals("ImmutableMap", immutableMapOf<String, String>()::class.simpleName)
 
         assertEquals(iMap1, iMap2)
         assertEquals(iMap1.entries, iMap2.entries)
@@ -80,6 +82,10 @@ class ImmutableUnitTest {
 
         val iSet1 = set1.toImmutableSet()
         val iSet2 = set2.toImmutableSet()
+        assertEquals("ImmutableSet", iSet1::class.simpleName)
+        assertNotEquals("ImmutableSet", emptySet<String>().toImmutableSet()::class.simpleName)
+        assertNotEquals("ImmutableSet", immutableSetOf<String>()::class.simpleName)
+
         assertEquals(iSet1, iSet2)
         assertEquals(iSet1.toString(), iSet2.toString())
         assertEquals(iSet1.hashCode(), iSet2.hashCode())

--- a/library/core-resource/src/commonTest/kotlin/io/matthewnelson/kmp/tor/core/resource/ImmutableUnitTest.kt
+++ b/library/core-resource/src/commonTest/kotlin/io/matthewnelson/kmp/tor/core/resource/ImmutableUnitTest.kt
@@ -52,15 +52,13 @@ class ImmutableUnitTest {
 
         val iMap1 = map1.toImmutableMap()
         val iMap2 = map2.toImmutableMap()
-        assertIs<ImmutableMap.Entry<String, String>>(iMap1.entries.first())
         assertIs<ImmutableSet<String>>(iMap1.entries)
-        assertIs<ImmutableList<String>>(iMap1.values)
         assertIs<ImmutableSet<String>>(iMap1.keys)
 
         assertEquals(iMap1, iMap2)
         assertEquals(iMap1.entries, iMap2.entries)
         assertEquals(iMap1.keys, iMap2.keys)
-        assertEquals(iMap1.values, iMap2.values)
+        assertNotEquals(iMap1.values, iMap2.values)
         assertContentEquals(iMap1.values, iMap2.values)
         assertEquals(iMap1.toString(), iMap2.toString())
         assertEquals(iMap1.hashCode(), iMap2.hashCode())

--- a/library/core-resource/src/commonTest/kotlin/io/matthewnelson/kmp/tor/core/resource/ImmutableUnitTest.kt
+++ b/library/core-resource/src/commonTest/kotlin/io/matthewnelson/kmp/tor/core/resource/ImmutableUnitTest.kt
@@ -16,27 +16,60 @@
 package io.matthewnelson.kmp.tor.core.resource
 
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.core.resource.ImmutableList.Companion.toImmutableList
 import io.matthewnelson.kmp.tor.core.resource.ImmutableMap.Companion.toImmutableMap
 import io.matthewnelson.kmp.tor.core.resource.ImmutableSet.Companion.toImmutableSet
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 @OptIn(InternalKmpTorApi::class)
 class ImmutableUnitTest {
 
     @Test
+    fun givenContents_whenTheSame_thenImmutableListEqualsOther() {
+        val list1 = mutableListOf("this", "that", "here", "there")
+        val list2 = list1.toMutableList()
+        assertEquals(list1, list2)
+
+        val iList1 = list1.toImmutableList()
+        val iList2 = list2.toImmutableList()
+        assertIs<ImmutableList<String>>(iList1.subList(0, 2))
+        assertEquals(iList1, iList2)
+        assertEquals(iList1.toString(), iList2.toString())
+        assertEquals(iList1.hashCode(), iList2.hashCode())
+
+        assertEquals(list1, iList1)
+        assertEquals(list1.toString(), iList1.toString())
+        assertEquals(list1.hashCode(), iList1.hashCode())
+    }
+    @Test
     fun givenContents_whenTheSame_thenImmutableMapEqualsOther() {
         val map1 = mutableMapOf("this" to "that", "here" to "there")
         val map2 = map1.toMutableMap()
         assertEquals(map1, map2)
+        assertEquals(map1.entries, map2.entries)
+        assertEquals(map1.keys, map2.keys)
+        assertNotEquals(map1.values, map2.values)
 
         val iMap1 = map1.toImmutableMap()
         val iMap2 = map2.toImmutableMap()
+        assertIs<ImmutableMap.Entry<String, String>>(iMap1.entries.first())
+        assertIs<ImmutableSet<String>>(iMap1.entries)
+        assertIs<ImmutableList<String>>(iMap1.values)
+        assertIs<ImmutableSet<String>>(iMap1.keys)
+
         assertEquals(iMap1, iMap2)
+        assertEquals(iMap1.entries, iMap2.entries)
+        assertEquals(iMap1.keys, iMap2.keys)
+        assertEquals(iMap1.values, iMap2.values)
+        assertContentEquals(iMap1.values, iMap2.values)
         assertEquals(iMap1.toString(), iMap2.toString())
         assertEquals(iMap1.hashCode(), iMap2.hashCode())
 
         assertEquals(map1, iMap1)
+        assertEquals(map1.entries, iMap1.entries)
+        assertEquals(map1.keys, iMap1.keys)
+        assertNotEquals(map1.values, iMap1.values)
+        assertContentEquals(map1.values, iMap1.values)
         assertEquals(map1.toString(), iMap1.toString())
         assertEquals(map1.hashCode(), iMap1.hashCode())
     }

--- a/library/core-resource/src/commonTest/kotlin/io/matthewnelson/kmp/tor/core/resource/ImmutableUnitTest.kt
+++ b/library/core-resource/src/commonTest/kotlin/io/matthewnelson/kmp/tor/core/resource/ImmutableUnitTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.core.resource
+
+import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
+import io.matthewnelson.kmp.tor.core.resource.ImmutableMap.Companion.toImmutableMap
+import io.matthewnelson.kmp.tor.core.resource.ImmutableSet.Companion.toImmutableSet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(InternalKmpTorApi::class)
+class ImmutableUnitTest {
+
+    @Test
+    fun givenContents_whenTheSame_thenImmutableMapEqualsOther() {
+        val map1 = mutableMapOf("this" to "that", "here" to "there")
+        val map2 = map1.toMutableMap()
+        assertEquals(map1, map2)
+
+        val iMap1 = map1.toImmutableMap()
+        val iMap2 = map2.toImmutableMap()
+        assertEquals(iMap1, iMap2)
+        assertEquals(iMap1.toString(), iMap2.toString())
+        assertEquals(iMap1.hashCode(), iMap2.hashCode())
+
+        assertEquals(map1, iMap1)
+        assertEquals(map1.toString(), iMap1.toString())
+        assertEquals(map1.hashCode(), iMap1.hashCode())
+    }
+
+    @Test
+    fun givenContents_whenTheSame_thenImmutableSetEqualsOther() {
+        val set1 = mutableSetOf("this", "that", "here", "there")
+        val set2 = set1.toMutableSet()
+        assertEquals(set1, set2)
+
+        val iSet1 = set1.toImmutableSet()
+        val iSet2 = set2.toImmutableSet()
+        assertEquals(iSet1, iSet2)
+        assertEquals(iSet1.toString(), iSet2.toString())
+        assertEquals(iSet1.hashCode(), iSet2.hashCode())
+
+        assertEquals(set1, iSet1)
+        assertEquals(set1.toString(), iSet1.toString())
+        assertEquals(set1.hashCode(), iSet1.hashCode())
+    }
+}

--- a/library/core-resource/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/core/resource/internal/-NonNativePlatform.kt
+++ b/library/core-resource/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/core/resource/internal/-NonNativePlatform.kt
@@ -15,9 +15,9 @@
  **/
 package io.matthewnelson.kmp.tor.core.resource.internal
 
-import io.matthewnelson.kmp.tor.core.resource.ImmutableMap
 import io.matthewnelson.kmp.tor.core.api.annotation.InternalKmpTorApi
 import io.matthewnelson.kmp.tor.core.resource.OSArch
+import io.matthewnelson.kmp.tor.core.resource.immutableMapOf
 import kotlin.jvm.JvmSynthetic
 
 @JvmSynthetic
@@ -28,7 +28,7 @@ internal const val PATH_OS_RELEASE = "/etc/os-release"
 @get:JvmSynthetic
 @InternalKmpTorApi
 internal val ARCH_MAP: Map<String, OSArch> by lazy {
-    ImmutableMap.of(
+    immutableMapOf(
         Pair("x86", OSArch.X86),
         Pair("i386", OSArch.X86),
         Pair("i486", OSArch.X86),

--- a/library/core-resource/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/core/resource/internal/-NonNativePlatform.kt
+++ b/library/core-resource/src/nonNativeMain/kotlin/io/matthewnelson/kmp/tor/core/resource/internal/-NonNativePlatform.kt
@@ -27,7 +27,7 @@ internal const val PATH_OS_RELEASE = "/etc/os-release"
 
 @get:JvmSynthetic
 @InternalKmpTorApi
-internal val ARCH_MAP: ImmutableMap<String, OSArch> by lazy {
+internal val ARCH_MAP: Map<String, OSArch> by lazy {
     ImmutableMap.of(
         Pair("x86", OSArch.X86),
         Pair("i386", OSArch.X86),


### PR DESCRIPTION
Closes #12 

Makes the `Immutable*` class types private with top-level access functions.