### PR TITLE
Use `LinkedHashSet` instead of `HashSet` for `ImmutableMap.entries`

### DIFF
--- a/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
+++ b/library/core-resource/src/commonMain/kotlin/io/matthewnelson/kmp/tor/core/resource/Immutable.kt
@@ -118,7 +118,7 @@ private class ImmutableMap<K, V>(private val delegate: Map<K, V>): Map<K, V> {
 
     override val entries: Set<Map.Entry<K, V>> by lazy {
         val entries = delegate.entries
-        val set = HashSet<Entry<K, V>>(entries.size, 1.0F)
+        val set = LinkedHashSet<Entry<K, V>>(entries.size, 1.0F)
         entries.mapTo(set) { Entry(it) }
         ImmutableSet(set)
     }


### PR DESCRIPTION
Closes #18 