### PR TITLE
Use flag `CLOEXEC` when opening `gzip` file on Unix

### DIFF
--- a/library/core-resource/src/mingwMain/kotlin/io/matthewnelson/kmp/tor/core/resource/internal/MingwPlatform.kt
+++ b/library/core-resource/src/mingwMain/kotlin/io/matthewnelson/kmp/tor/core/resource/internal/MingwPlatform.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.core.resource.internal
+
+internal actual val IsWindows: Boolean = true

--- a/library/core-resource/src/unixMain/kotlin/io/matthewnelson/kmp/tor/core/resource/internal/UnixPlatform.kt
+++ b/library/core-resource/src/unixMain/kotlin/io/matthewnelson/kmp/tor/core/resource/internal/UnixPlatform.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.tor.core.resource.internal
+
+internal actual val IsWindows: Boolean = false


### PR DESCRIPTION
Closes #34